### PR TITLE
Improved support for Chroma Link

### DIFF
--- a/Ambilight/Logic/LinkLogic.cs
+++ b/Ambilight/Logic/LinkLogic.cs
@@ -29,32 +29,33 @@ namespace Ambilight.Logic
         /// <param name="newImage">ScreenShot</param>
         public void Process(Bitmap newImage)
         {
-            Bitmap map = ImageManipulation.ResizeImage(newImage, 2, 2);
+            Bitmap map = ImageManipulation.ResizeImage(newImage, 4, 1);
             map = ImageManipulation.ApplySaturation(map, _settings.Saturation);
-            GenerateLinkGrid(map);
-
+            
+            ApplyImageToGrid(map);
+            ApplyC1(ImageManipulation.ResizeImage(map, 1, 1));
             _chroma.ChromaLink.SetCustomAsync(_linkGrid);
+            map.Dispose();
+        }
+
+        private void ApplyC1(Bitmap map)
+        {
+            Color color = map.GetPixel(0,0);
+            _linkGrid[0] = new ColoreColor((byte)color.R, (byte)color.G, (byte)color.B);
         }
 
         /// <summary>
         /// From a given resized screenshot, an ambilight effect will be created for the keyboard
         /// </summary>
         /// <param name="map">resized screenshot</param>
-        private void GenerateLinkGrid(Bitmap map)
+        private void ApplyImageToGrid(Bitmap map)
         {
             //Iterating over each key and set it to the corrosponding color of the resized Screenshot
-            for (var r = 1; r <= 2; r++)
+            for (int i = 1; i < Colore.Effects.ChromaLink.ChromaLinkConstants.MaxLeds; i++)
             {
-                for (var c = 0; c < 2; c++)
-                {
-                    System.Drawing.Color color;
-                    color = map.GetPixel(c, r-1);
-                    if (r == 2) r++;
-                    _linkGrid[c + r] = new ColoreColor((byte)color.R, (byte)color.G, (byte)color.B);
-                    if (r > 2) r--;
-                }
+                Color color = map.GetPixel(i-1,0);
+                _linkGrid[i] = new ColoreColor((byte)color.R, (byte)color.G, (byte)color.B);
             }
-            _linkGrid[0] = _linkGrid[1];
         }
     }
 }


### PR DESCRIPTION
Setting the overall average light as the default Value for all Chroma Link devices, that don't support channel 2-5.

Changing the lighting for channel 2-5 for devices that support these channels.